### PR TITLE
reqPath already contains 'require'

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,6 +55,10 @@ module.exports = function(options) {
             .map(function(reqName) {
                 var reqPath = options.requires[reqName];
 
+                if(reqPath.indexOf('require')!==-1){
+                    return 'var ' + reqName + ' = '+ reqPath+';';
+                }
+                
                 return 'var ' + reqName + ' = require(\'' + reqPath + '\');';
             })
 


### PR DESCRIPTION
This fix make gulp-jsxify work also with react-route and probably with all the other libraries that require a component from an external library.

```
<div className={this.state.loading ? "application loading" : "application"}>
{this.state.loading ? <div style={{float: "right"}}>loading...</div> : null}
<h1>react-starter2</h1>
<button onClick={this.update}>Update data</button>
<RouteHandler />
</div>

var RouteHandler = require("react-router").RouteHandler;
```
